### PR TITLE
Add target prop to dialog_button.vue

### DIFF
--- a/src/stateless/dialog_button.vue
+++ b/src/stateless/dialog_button.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <a v-if="href" :href="href" class="dialog-button__link" @click="click">
+        <a v-if="href" :href="href" :target="target" class="dialog-button__link" @click="click">
             <dialog-button :disabled="disabled" :loading="loading" :error="error">
                 <slot></slot>
             </dialog-button>
@@ -27,6 +27,7 @@ export default {
         loading: { type: Boolean, default: false },
         error: { type: Boolean, default: false },
         href: { type: String },
+        target: { type: String, default: '_self' },
     },
     methods: {
         click () {


### PR DESCRIPTION
Target prop ('string') that is used as 'target' for <a> html element added to dialog_button.vue.
Default is set to previous value so the change is fully backwards compatible.