### PR TITLE
Only select what is not filtered out by search query

### DIFF
--- a/src/stateless/multiselect.vue
+++ b/src/stateless/multiselect.vue
@@ -92,8 +92,8 @@ export default {
         allOptions () {
             return this.options.concat(this.queryOptions)
         },
-        allIds () {
-            return itemsUtils.getLeafIds(this.allOptions)
+        allPossibleIds () {
+            return itemsUtils.getLeafIds(this.listItems)
         },
         listItems () {
             let result = this.allOptions
@@ -153,7 +153,7 @@ export default {
     },
     methods: {
         selectAll () {
-            this.$emit('input', this.allIds)
+            this.$emit('input', this.allPossibleIds)
         },
         clearAll () {
             this.$emit('input', [])


### PR DESCRIPTION
Fixes [reported issue](https://docs.google.com/document/d/1QGyghiYU3ZbSVAy6x2RzVl6-NLHJ4ipJVjawnHfi1j0/edit#heading=h.dw1eswsv9o1r)

when user searches and narrows down the list, and clicks on "select all" we’d expect to select only all options from the narrow list – currently it selects all options from list.