### PR TITLE
Use tabular nums in chip

### DIFF
--- a/src/stateless/Chip.vue
+++ b/src/stateless/Chip.vue
@@ -55,6 +55,7 @@ export default {
 .chip__metadata {
     font-family: @regular-text-font;
     padding-right: 5px;
+    font-variant-numeric: tabular-nums;
 }
 
 .chip__remove-btn {


### PR DESCRIPTION
@andrejventa as mentioned in mail thread. Using this CSS property will fix filter jumping on VCE when all filters have same number of digits. Example: 
![single digits](https://user-images.githubusercontent.com/957321/46223151-661a7f00-c307-11e8-95bf-e27447851c65.png)

But it won't help when we have filters where 17/17 can drop to 5/17:
![digit drop](https://user-images.githubusercontent.com/957321/46223251-b5f94600-c307-11e8-84ac-b2348aff0da0.png)

See screencast: https://file-ihpjicenjt.now.sh/

In that case, filters will still "jump" even when we use this CSS property. And I don't really have a good solution for it. We could pad all numbers with `0`, but that isn't really nice.